### PR TITLE
chore: onboard new TSA codebase name

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -23,6 +23,9 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
+    tsa:
+      config:
+        codebaseName: iconv-lite-umd
     npmPackages:
       - name: iconv-lite-umd
 


### PR DESCRIPTION
TSAUpload keeps failing for this pipeline, so the TSA codebase associated with it might have expired. This PR overrides the TSA codebase name to create and associate a new TSA codebase with this pipeline.